### PR TITLE
Update the guide to reflect the issue with CLT Beta 3 and 4

### DIFF
--- a/content/en/2023/2023-06-07-playing-diablo-4-on-macos/index.md
+++ b/content/en/2023/2023-06-07-playing-diablo-4-on-macos/index.md
@@ -37,7 +37,13 @@ After downloading and installing, verify that they are used by default. Open ter
 xcode-select -p
 ```
 
-It should print something like:
+If your system does not have Xcode installed, it should print something like:
+
+```text
+/Library/Developer/CommandLineTools
+```
+
+If you do, it should print something like:
 
 ```text
 /Applications/Xcode-beta.app/Contents/Developer

--- a/content/en/2023/2023-06-07-playing-diablo-4-on-macos/index.md
+++ b/content/en/2023/2023-06-07-playing-diablo-4-on-macos/index.md
@@ -25,9 +25,11 @@ Don't want to get credit on that, as I have found an almost working for me solut
 I am running macOS 14 Developer Beta 1 (Sonoma), but some people mentioned that it might work on macOS Ventura as well (the latest release 13.4).
 You need to have an Apple Silicon Mac, as it will not work on Intel-based Macs.
 
-### Install Command Line Tools for Xcode 15 Beta
+### Install Command Line Tools for Xcode 15 Beta 2
 
-Download Command Line Tools from [https://developer.apple.com/download/all/](https://developer.apple.com/download/all/?q=xcode%20command%20line%20tools%2015).
+Download Command Line Tools from [https://developer.apple.com/download/all/](https://developer.apple.com/download/all/?q=Command%20Line%20Tools%20for%20Xcode%2015%20beta%202).
+
+**Make sure to install the Beta 2 version!** Versions 3 and 4 have a [known issue](https://developer.apple.com/forums/thread/732940) which won't allow you to progress further in the guide.
 
 After downloading and installing, verify that they are used by default. Open terminal and run:
 


### PR DESCRIPTION
Due to the [issue](https://developer.apple.com/forums/thread/732940) with newer Command Line Tools for Xcode 15 beta (3 and 4 both have this issue), I've updated the guide stressing that you need the **beta 2** version specifically.

Another update is regarding the `xcode-select -p` command output:
- if you have Xcode installed, then your guide is correct, **but**
- if you don't (and you don't need to have it in order to build the toolkit), then the output will be `/Library/Developer/CommandLineTools` instead of `/Applications/Xcode-beta.app/Contents/Developer`